### PR TITLE
Seperate Abs implementation from Neg for Measurement

### DIFF
--- a/Quantities/Core.idr
+++ b/Quantities/Core.idr
@@ -333,4 +333,6 @@ implementation Num a => Num (Measurement unitLess a) where
 implementation Neg a => Neg (Measurement unitLess a) where
   negate x = negate (getValue x) =| unitLess
   x - y = (getValue x - getValue y) =| unitLess
+
+implementation Abs a => Abs (Measurement unitLess a) where
   abs x = abs (getValue x) =| unitLess


### PR DESCRIPTION
This allows quantities to build with idris 1.2.0 now that Abs is a separate interface from Neg. 